### PR TITLE
NullReferenceException in ChromiumWebBrowser if not yet in VisualTree

### DIFF
--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -857,7 +857,7 @@ namespace CefSharp.Wpf
                 return;
             }
 
-            managedCefBrowserAdapter.CreateOffscreenBrowser(source.Handle, BrowserSettings, Address);
+            managedCefBrowserAdapter.CreateOffscreenBrowser(source == null ? IntPtr.Zero : source.Handle, BrowserSettings, Address);
             browserCreated = true;
         }
 


### PR DESCRIPTION
ChromiumWebBrowser throws a NullReferenceException if its ActualSize changes before it appears in the VisualTree #985